### PR TITLE
Mirror Phase 1 of Redis audit fixes from saltstack/salt#69040

### DIFF
--- a/changelog/99001.fixed.md
+++ b/changelog/99001.fixed.md
@@ -1,0 +1,6 @@
+Fixed `redis.get_master_ip` silently dropping the `password` argument. The
+function was forwarding its arguments positionally to `_connect`, but
+`_connect`'s third positional slot is `db`, not `password`, so the
+caller's password landed in the database-index argument and the actual
+password fell through to `config.option("redis.password")`. Arguments
+are now passed by keyword. Mirrors saltstack/salt#69029 (PR #69040).

--- a/changelog/99002.fixed.md
+++ b/changelog/99002.fixed.md
@@ -1,0 +1,7 @@
+Fixed `salt.modules.redismod._connect` rejecting valid `db=0`. The helper
+used a truthy check (`if not db`) to decide whether to fall back to
+`config.option("redis.db")`, but `not 0` is `True`, so an explicitly
+supplied `db=0` was silently replaced by the configured value. The check
+is now `if db is None`, matching the pattern already used by the sibling
+`_sconnect` helper in the same module. Other arguments keep their
+truthy-check semantics on purpose. Mirrors saltstack/salt#69030 (PR #69040).

--- a/changelog/99003.fixed.md
+++ b/changelog/99003.fixed.md
@@ -1,0 +1,9 @@
+Fixed two distinct bugs in the `redis_sentinel` engine that together
+prevented it from being usable. `start()` no longer raises
+`AttributeError: 'dict_values' object has no attribute 'pop'` on
+Python 3 (the `dict.values()` result is now wrapped in `list(...)`).
+`Listener` and `start()` now accept an optional `password` argument
+and forward it to the redis client, allowing the engine to authenticate
+against a Sentinel that requires AUTH; the default of `None` keeps
+existing configurations working unchanged. Mirrors saltstack/salt#69031
+(PR #69040).

--- a/changelog/99005.fixed.md
+++ b/changelog/99005.fixed.md
@@ -1,0 +1,13 @@
+Fixed three closely-related bugs in `saltext.redis.cache.redis_cache`
+that together broke hierarchical-bank semantics: `_build_bank_hier`
+now registers each child bank name in both the parent's `$BANK_` set
+(consumed by `flush()` tree traversal) and the parent's `$BANKEYS_`
+set (consumed by `list_()`); `_get_banks_to_remove` now decodes the
+bytes returned by `smembers` and skips the `"."` placeholder, so
+recursive `flush()` of a parent bank actually descends into sub-banks
+instead of corrupting the path; and `flush(bank)` of a sub-bank now
+removes the flushed bank's own reference from its parent's index sets
+so `list_(parent)` no longer reports it as present. Together these
+fixes restore `cache.list("minions")`, `salt-run manage.present` and
+`salt-run manage.up` for masters configured with `cache: redis`.
+Mirrors saltstack/salt#69033 (PR #69040).

--- a/changelog/99006.fixed.md
+++ b/changelog/99006.fixed.md
@@ -1,0 +1,10 @@
+Fixed `saltext.redis.tokens.rediscluster` being unable to retrieve any
+eauth token. The cluster client was created with `decode_responses=True`,
+which caused `redis_client.get()` to return `str` and broke
+`salt.payload.loads` (msgpack rejects `str`); it also caused
+`redis_client.keys()` to return `str` and broke
+`[k.decode("utf8") for k in ...]` (`str` has no `.decode`). Both errors
+were swallowed by broad `except Exception` handlers, so eauth appeared
+to silently reject every token. `decode_responses=True` is removed;
+values now round-trip as bytes through msgpack as the rest of the
+module already expected. Mirrors saltstack/salt#69035 (PR #69040).

--- a/changelog/99007.changed.md
+++ b/changelog/99007.changed.md
@@ -1,0 +1,9 @@
+Replaced blocking `KEYS` calls with `SCAN` in
+`saltext.redis.returners.redis_return.get_jids` and
+`clean_old_jobs`. Per the Redis docs `KEYS` is for "debugging and
+special operations" -- it walks the entire keyspace synchronously and
+blocks the server thread; on a master with hundreds of thousands of
+jobs each call could stall the Redis server (and therefore every
+client of it) for seconds. `SCAN` walks the keyspace incrementally
+without blocking, with no Salt-visible API change. Mirrors
+saltstack/salt#69037 (PR #69040).

--- a/changelog/99008.fixed.md
+++ b/changelog/99008.fixed.md
@@ -1,0 +1,5 @@
+Fixed `saltext.redis.returners.redis_return.returner` writing the
+`<minion>:<fun>` last-jid pointer with no TTL, so any (minion, fun)
+pair that stopped running stuck in Redis indefinitely. The pointer
+now expires on the same schedule (`keep_jobs_seconds`) as the
+`ret:<jid>` hash. Mirrors saltstack/salt#69038 (PR #69040).

--- a/changelog/99009.fixed.md
+++ b/changelog/99009.fixed.md
@@ -1,0 +1,7 @@
+Fixed `saltext.redis.returners.redis_return.get_fun` always returning
+`{}` because it read return data from a `<minion>:<jid>` key that no
+other code in the module ever writes -- a leftover from an older
+storage schema. The current `returner` writes return data as fields
+of a `ret:<jid>` hash; `get_fun` now reads the per-minion field via
+`HGET ret:<jid> <minion>`, matching the canonical storage layout
+already used by `get_jid`. Mirrors saltstack/salt#69039 (PR #69040).

--- a/src/saltext/redis/cache/redis_cache.py
+++ b/src/saltext/redis/cache/redis_cache.py
@@ -151,7 +151,6 @@ Cluster Configuration Example:
     cache.redis.separator: '@'
 """
 
-import itertools
 import logging
 import time
 
@@ -329,18 +328,40 @@ def _get_bank_keys_redis_key(bank):
 def _build_bank_hier(bank, redis_pipe):
     """
     Build the bank hierarchy from the root of the tree.
-    If already exists, it won't rewrite.
-    It's using the Redis pipeline,
-    so there will be only one interaction with the remote server.
+
+    For each level in the bank path:
+
+    - ensure a ``.`` placeholder exists in ``$BANK_<level>`` so that an
+      empty bank still has a recognisable record;
+    - for every non-root level, register this segment as a child of its
+      parent in both ``$BANK_<parent>`` (consumed by the flush
+      tree-traversal in ``_get_banks_to_remove``) and
+      ``$BANKEYS_<parent>`` (consumed by ``list_()``). Without this,
+      ``list_("minions")`` reads an empty set even though the data is
+      stored correctly under ``minions/<id>``, breaking
+      ``CkMinions.connected_ids()`` and therefore
+      ``salt-run manage.present`` / ``manage.up`` for any deployment
+      that uses the redis cache backend.
+
+    Uses the Redis pipeline so there is only one round-trip with the
+    server.
     """
-
-    def joinbanks(*banks):
-        return "/".join(banks)
-
-    for bank_path in itertools.accumulate(bank.split("/"), joinbanks):
+    parts = bank.split("/")
+    for index, segment in enumerate(parts):
+        bank_path = "/".join(parts[: index + 1])
         bank_set = _get_bank_redis_key(bank_path)
         log.debug("Adding %s to %s", bank, bank_set)
         redis_pipe.sadd(bank_set, ".")
+        if index > 0:
+            parent_path = "/".join(parts[:index])
+            # Register the child in BOTH the parent's $BANK_ set (so
+            # ``_get_banks_to_remove`` finds it for flush traversal)
+            # AND the parent's $BANKEYS_ set (so ``list_()`` returns
+            # it). Both reads exist in the codebase and both must see
+            # the child for the cache to behave like the localfs
+            # backend.
+            redis_pipe.sadd(_get_bank_redis_key(parent_path), segment)
+            redis_pipe.sadd(_get_bank_keys_redis_key(parent_path), segment)
 
 
 def _get_banks_to_remove(redis_server, bank, path=""):
@@ -357,6 +378,16 @@ def _get_banks_to_remove(redis_server, bank, path=""):
     if not child_banks:
         return bank_paths_to_remove  # this bank does not have any child banks so we stop here
     for child_bank in child_banks:
+        # ``smembers`` returns ``bytes`` because the cache client is not
+        # configured with ``decode_responses=True``; decode here so that
+        # the recursive path concatenation does not embed ``b'foo'`` in
+        # the resulting Redis key name.
+        if isinstance(child_bank, bytes):
+            child_bank = child_bank.decode()
+        # Skip the ``.`` placeholder written by ``_build_bank_hier`` --
+        # it marks "this bank exists" and is not itself a sub-bank.
+        if child_bank == ".":
+            continue
         bank_paths_to_remove.extend(
             _get_banks_to_remove(redis_server, child_bank, path=current_path)
         )
@@ -491,6 +522,15 @@ def flush(bank, key=None):
             redis_pipe.delete(bank_key)
             log.debug("Removing the %s bank (%s)", bank_path, bank_key)
             # delete the bank key itself
+        # Drop this bank's own reference from its parent's index sets,
+        # otherwise ``list_(parent)`` would still report the bank as
+        # present after a full flush. ``_build_bank_hier`` writes into
+        # both the parent's $BANK_ and $BANKEYS_ sets (see that
+        # function's docstring); both must be cleaned up here.
+        if "/" in bank:
+            parent_path, segment = bank.rsplit("/", 1)
+            redis_pipe.srem(_get_bank_redis_key(parent_path), segment)
+            redis_pipe.srem(_get_bank_keys_redis_key(parent_path), segment)
     else:
         redis_key = _get_key_redis_key(bank, key)
         redis_pipe.delete(redis_key)  # delete the key cached

--- a/src/saltext/redis/engines/redis_sentinel.py
+++ b/src/saltext/redis/engines/redis_sentinel.py
@@ -43,7 +43,7 @@ def __virtual__():
 
 
 class Listener:
-    def __init__(self, host=None, port=None, channels=None, tag=None):
+    def __init__(self, host=None, port=None, channels=None, tag=None, password=None):
         if host is None:
             host = "localhost"
         if port is None:
@@ -54,7 +54,9 @@ class Listener:
             tag = "salt/engine/redis_sentinel"
         super().__init__()
         self.tag = tag
-        self.redis = redis.StrictRedis(host=host, port=port, decode_responses=True)
+        self.redis = redis.StrictRedis(
+            host=host, port=port, password=password, decode_responses=True
+        )
         self.pubsub = self.redis.pubsub()
         self.pubsub.psubscribe(channels)
         self.fire_master = salt.utils.event.get_master_event(
@@ -95,10 +97,24 @@ class Listener:
             self.work(item)
 
 
-def start(hosts, channels, tag=None):
+def start(hosts, channels, tag=None, password=None):
     if tag is None:
         tag = "salt/engine/redis_sentinel"
     with salt.client.LocalClient() as local:
-        ips = local.cmd(hosts["matching"], "network.ip_addrs", [hosts["interface"]]).values()
-    client = Listener(host=ips.pop()[0], port=hosts["port"], channels=channels, tag=tag)
+        # ``.values()`` returns a Python 3 ``dict_values`` view; wrap in
+        # ``list`` so ``.pop()`` is available. Without the wrapper the
+        # engine raises ``AttributeError`` the first time it starts and
+        # has therefore never actually run on Python 3.
+        ips = list(
+            local.cmd(
+                hosts["matching"], "network.ip_addrs", [hosts["interface"]]
+            ).values()
+        )
+    client = Listener(
+        host=ips.pop()[0],
+        port=hosts["port"],
+        channels=channels,
+        tag=tag,
+        password=password,
+    )
     client.run()

--- a/src/saltext/redis/engines/redis_sentinel.py
+++ b/src/saltext/redis/engines/redis_sentinel.py
@@ -101,17 +101,18 @@ def start(hosts, channels, tag=None, password=None):
     if tag is None:
         tag = "salt/engine/redis_sentinel"
     with salt.client.LocalClient() as local:
-        # ``.values()`` returns a Python 3 ``dict_values`` view; wrap in
-        # ``list`` so ``.pop()`` is available. Without the wrapper the
-        # engine raises ``AttributeError`` the first time it starts and
-        # has therefore never actually run on Python 3.
-        ips = list(
-            local.cmd(
-                hosts["matching"], "network.ip_addrs", [hosts["interface"]]
-            ).values()
+        ip_results = local.cmd(
+            hosts["matching"], "network.ip_addrs", [hosts["interface"]]
         )
+    if not ip_results:
+        log.error(
+            "redis_sentinel: no minions matched %r; cannot pick a listener "
+            "host. Check the 'matching' target in the engine config.",
+            hosts["matching"],
+        )
+        return
     client = Listener(
-        host=ips.pop()[0],
+        host=next(reversed(ip_results.values()))[0],
         port=hosts["port"],
         channels=channels,
         tag=tag,

--- a/src/saltext/redis/modules/redismod.py
+++ b/src/saltext/redis/modules/redismod.py
@@ -48,7 +48,10 @@ def _connect(host=None, port=None, db=None, password=None):
         host = __salt__["config.option"]("redis.host")
     if not port:
         port = __salt__["config.option"]("redis.port")
-    if not db:
+    if db is None:
+        # Use ``is None`` rather than ``not db`` because ``0`` is the default
+        # Redis database index and a perfectly valid explicit value: the
+        # truthy check would silently replace it with the config value.
         db = __salt__["config.option"]("redis.db")
     if not password:
         password = __salt__["config.option"]("redis.password")

--- a/src/saltext/redis/modules/redismod.py
+++ b/src/saltext/redis/modules/redismod.py
@@ -725,7 +725,7 @@ def get_master_ip(host=None, port=None, password=None):
 
         salt '*' redis.get_master_ip
     """
-    server = _connect(host, port, password)
+    server = _connect(host=host, port=port, password=password)
     srv_info = server.info()
     ret = (srv_info.get("master_host", ""), srv_info.get("master_port", ""))
     return dict(list(zip(("master_host", "master_port"), ret)))

--- a/src/saltext/redis/returners/redis_return.py
+++ b/src/saltext/redis/returners/redis_return.py
@@ -220,7 +220,13 @@ def returner(ret):
     minion, jid = ret["id"], ret["jid"]
     pipeline.hset(f"ret:{jid}", minion, salt.utils.json.dumps(ret))
     pipeline.expire(f"ret:{jid}", _get_ttl())
-    pipeline.set("{}:{}".format(minion, ret["fun"]), jid)  # pylint: disable=consider-using-f-string
+    # Apply the same TTL to the ``<minion>:<fun>`` last-jid pointer.
+    # Without ``ex=`` the key was written with no expiry and never
+    # cleaned up, so any (minion, fun) pair that stopped running stuck
+    # in Redis indefinitely.
+    pipeline.set(  # pylint: disable=consider-using-f-string
+        "{}:{}".format(minion, ret["fun"]), jid, ex=_get_ttl()
+    )
     pipeline.sadd("minions", minion)
     pipeline.execute()
 

--- a/src/saltext/redis/returners/redis_return.py
+++ b/src/saltext/redis/returners/redis_return.py
@@ -289,7 +289,13 @@ def get_jids():
     """
     serv = _get_serv(ret=None)
     ret = {}
-    for s in serv.mget(serv.keys("load:*")):
+    # ``SCAN`` walks the keyspace incrementally and never blocks the
+    # Redis server, unlike ``KEYS``. Order is not guaranteed but the
+    # returner does not rely on it.
+    load_keys = list(serv.scan_iter(match="load:*"))
+    if not load_keys:
+        return ret
+    for s in serv.mget(load_keys):
         if s is None:
             continue
         load = salt.utils.json.loads(s)
@@ -316,14 +322,18 @@ def clean_old_jobs():
     do manually cleaning here.
     """
     serv = _get_serv(ret=None)
-    ret_jids = serv.keys("ret:*")
-    living_jids = set(serv.keys("load:*"))
+    # ``SCAN`` walks the keyspace incrementally; ``KEYS`` blocks the
+    # Redis server until it has scanned every key. ``clean_old_jobs``
+    # is invoked from the master scheduler, so the cumulative load of
+    # blocking the server twice (``ret:*`` and ``load:*``) on every
+    # tick is avoided here.
+    living_jids = set(serv.scan_iter(match="load:*"))
     to_remove = []
-    for ret_key in ret_jids:
+    for ret_key in serv.scan_iter(match="ret:*"):
         load_key = ret_key.replace("ret:", "load:", 1)
         if load_key not in living_jids:
             to_remove.append(ret_key)
-    if len(to_remove) != 0:
+    if to_remove:
         serv.delete(*to_remove)
         log.debug("clean old jobs: %s", to_remove)
 

--- a/src/saltext/redis/returners/redis_return.py
+++ b/src/saltext/redis/returners/redis_return.py
@@ -283,7 +283,12 @@ def get_fun(fun):
             continue
         if not jid:
             continue
-        data = serv.get(f"{minion}:{jid}")
+        # The return data lives as a field of the ``ret:<jid>`` hash
+        # (written by ``returner`` via ``hset``), not under a
+        # ``<minion>:<jid>`` key (no such key is ever written by this
+        # module). Reading the hash field is what ``get_jid`` already
+        # does.
+        data = serv.hget(f"ret:{jid}", minion)
         if data:
             ret[minion] = salt.utils.json.loads(data)
     return ret

--- a/src/saltext/redis/tokens/rediscluster.py
+++ b/src/saltext/redis/tokens/rediscluster.py
@@ -46,11 +46,21 @@ def _redis_client(opts):
     """
     Connect to the redis host and return a RedisCluster client object.
     If connection fails then return None.
+
+    Note: ``decode_responses`` is intentionally NOT enabled here. Token
+    values are msgpack-serialised by ``salt.payload`` and must round-trip
+    as bytes; ``list_tokens`` likewise calls ``.decode()`` on each key
+    it gets back, which requires bytes. Enabling ``decode_responses=True``
+    makes ``redis_client.get()`` and ``redis_client.keys()`` return
+    ``str`` instead, which would break both ``get_token`` (msgpack
+    rejects ``str``) and ``list_tokens`` (``str.decode`` does not
+    exist) -- and the broad ``except`` handlers in those callers would
+    silently turn every read into an empty result.
     """
     redis_host = opts.get("eauth_redis_host", "localhost")
     redis_port = opts.get("eauth_redis_port", 6379)
     try:
-        return rediscluster.RedisCluster(host=redis_host, port=redis_port, decode_responses=True)
+        return rediscluster.RedisCluster(host=redis_host, port=redis_port)
     except rediscluster.exceptions.RedisClusterException as err:
         log.warning("Failed to connect to redis at %s:%s - %s", redis_host, redis_port, err)
         return None

--- a/tests/unit/cache/test_redis_cache.py
+++ b/tests/unit/cache/test_redis_cache.py
@@ -1,0 +1,317 @@
+"""
+Unit tests for ``salt.cache.redis_cache`` hierarchical-bank fixes.
+
+Three closely-related bugs are covered here:
+
+1. ``_build_bank_hier`` registers child bank names in both
+   ``$BANK_<parent>`` (used by the flush tree-traversal) and
+   ``$BANKEYS_<parent>`` (used by ``list_``). Without this,
+   ``cache.list("minions")`` returns empty and ``salt-run
+   manage.present`` reports no minions even when their data is in
+   Redis.
+2. ``_get_banks_to_remove`` decodes the ``bytes`` returned by
+   ``smembers`` and skips the ``"."`` placeholder, so recursive flush
+   can actually descend into sub-banks.
+3. ``flush(bank, key=None)`` removes the flushed bank's reference
+   from its parent's index sets, so ``list_(parent)`` no longer
+   reports the freshly-flushed bank as still present.
+"""
+
+import pytest
+
+from saltext.redis.cache import redis_cache
+from unittest.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {redis_cache: {"__opts__": {}}}
+
+
+def _saddargs(pipe):
+    """Return the list of (set_name, value) tuples from ``pipe.sadd`` calls."""
+    return [tuple(call.args) for call in pipe.sadd.call_args_list]
+
+
+def _sremargs(pipe):
+    """Return the list of (set_name, value) tuples from ``pipe.srem`` calls."""
+    return [tuple(call.args) for call in pipe.srem.call_args_list]
+
+
+# ---------------------------------------------------------------------------
+# _build_bank_hier: parent-index population
+# ---------------------------------------------------------------------------
+
+
+class TestBuildBankHier:
+    """
+    Each ``store(bank, key, ...)`` call eventually calls
+    ``_build_bank_hier(bank, pipe)`` to make sure every level of the
+    bank path is recorded. Before the fix this only wrote a ``.``
+    placeholder at each level; after the fix every non-root level also
+    appears as a member of its parent's ``$BANK_`` and ``$BANKEYS_``
+    sets.
+    """
+
+    def test_single_level_only_writes_placeholder(self):
+        pipe = MagicMock()
+        redis_cache._build_bank_hier("minions", pipe)
+        calls = _saddargs(pipe)
+        assert ("$BANK_minions", ".") in calls
+        # Nothing else should be written for a top-level bank: there is
+        # no parent above ``minions`` to register under.
+        assert len(calls) == 1
+
+    def test_two_levels_register_child_in_parent_bank_set(self):
+        """``$BANK_minions`` must contain ``foo`` (used by flush)."""
+        pipe = MagicMock()
+        redis_cache._build_bank_hier("minions/foo", pipe)
+        calls = _saddargs(pipe)
+        assert ("$BANK_minions", "foo") in calls
+
+    def test_two_levels_register_child_in_parent_bankkeys_set(self):
+        """``$BANKEYS_minions`` must contain ``foo`` (used by list_)."""
+        pipe = MagicMock()
+        redis_cache._build_bank_hier("minions/foo", pipe)
+        calls = _saddargs(pipe)
+        assert ("$BANKEYS_minions", "foo") in calls
+
+    def test_two_levels_placeholder_at_each_level(self):
+        pipe = MagicMock()
+        redis_cache._build_bank_hier("minions/foo", pipe)
+        calls = _saddargs(pipe)
+        assert ("$BANK_minions", ".") in calls
+        assert ("$BANK_minions/foo", ".") in calls
+
+    def test_three_levels_full_chain_registered(self):
+        pipe = MagicMock()
+        redis_cache._build_bank_hier("minions/host01.example.com/data", pipe)
+        calls = _saddargs(pipe)
+
+        # Placeholder at every level.
+        assert ("$BANK_minions", ".") in calls
+        assert ("$BANK_minions/host01.example.com", ".") in calls
+        assert ("$BANK_minions/host01.example.com/data", ".") in calls
+
+        # Each parent->child step recorded in BOTH parent indices.
+        assert ("$BANK_minions", "host01.example.com") in calls
+        assert ("$BANKEYS_minions", "host01.example.com") in calls
+        assert ("$BANK_minions/host01.example.com", "data") in calls
+        assert ("$BANKEYS_minions/host01.example.com", "data") in calls
+
+
+# ---------------------------------------------------------------------------
+# _get_banks_to_remove: bytes decoding and "." placeholder skipping
+# ---------------------------------------------------------------------------
+
+
+class TestGetBanksToRemove:
+    def test_decodes_bytes_smembers_result(self):
+        """
+        ``redis_cache`` is not configured with ``decode_responses=True``,
+        so ``smembers`` returns bytes. The recursion must decode them
+        before concatenating into the path -- otherwise the next
+        ``smembers`` lookup hits a corrupted key like
+        ``$BANK_minions/b'foo'``.
+        """
+        # First call: $BANK_minions returns {b"foo"}.
+        # Second call: $BANK_minions/foo returns {b"."} (only placeholder).
+        smembers_results = {
+            "$BANK_minions": {b"foo"},
+            "$BANK_minions/foo": {b"."},
+        }
+        server = MagicMock()
+        server.smembers.side_effect = lambda key: smembers_results.get(key, set())
+
+        result = redis_cache._get_banks_to_remove(server, "minions")
+        # Must contain the cleanly-formed path, not the bytes-corrupted
+        # variant.
+        assert "minions/foo" in result
+        assert "minions/b'foo'" not in result
+
+    def test_skips_dot_placeholder(self):
+        """
+        ``$BANK_<bank>`` always contains a ``"."`` placeholder
+        (written by ``_build_bank_hier`` to mark the bank's existence).
+        Recursion must not treat it as a real sub-bank, otherwise
+        ``bank_paths_to_remove`` ends up polluted with phantom paths
+        like ``minions/foo/.``.
+        """
+        smembers_results = {
+            "$BANK_minions/foo": {b".", b"data"},
+            "$BANK_minions/foo/data": {b"."},
+        }
+        server = MagicMock()
+        server.smembers.side_effect = lambda key: smembers_results.get(key, set())
+
+        result = redis_cache._get_banks_to_remove(server, "minions/foo")
+        assert "minions/foo" in result
+        assert "minions/foo/data" in result
+        # No phantom path with a "." segment.
+        assert all("/." not in path for path in result)
+
+    def test_handles_no_children(self):
+        """A leaf bank with empty smembers returns just itself."""
+        server = MagicMock()
+        server.smembers.return_value = set()
+        result = redis_cache._get_banks_to_remove(server, "minions/foo")
+        assert result == ["minions/foo"]
+
+
+# ---------------------------------------------------------------------------
+# flush(): remove the flushed bank's reference from its parent's indices
+# ---------------------------------------------------------------------------
+
+
+class TestFlushOrphanCleanup:
+    """
+    After ``flush("minions/foo")`` returns, ``cache.list("minions")``
+    must no longer report ``foo``. Without the parent-index cleanup,
+    the patched ``_build_bank_hier`` populates the parent set but
+    ``flush`` never empties it again, leaving an orphan reference.
+    """
+
+    def test_flush_subbank_srems_self_from_parent_bank_set(self):
+        pipe = MagicMock()
+        server = MagicMock()
+        server.pipeline.return_value = pipe
+        # ``smembers`` returns no children; we only care about the
+        # final ``srem`` calls.
+        server.smembers.return_value = set()
+        # ``redis_pipe.execute()`` is invoked twice in the ``key is None``
+        # branch: once after the smembers gathers (returns the list of
+        # subtree key-sets) and once at the very end (returns the
+        # delete results). Both must yield iterables.
+        pipe.execute.side_effect = [[set()], None]
+
+        with patch.object(redis_cache, "_get_redis_server", return_value=server):
+            redis_cache.flush("minions/foo")
+
+        srem_calls = _sremargs(pipe)
+        assert ("$BANK_minions", "foo") in srem_calls
+
+    def test_flush_subbank_srems_self_from_parent_bankkeys_set(self):
+        pipe = MagicMock()
+        server = MagicMock()
+        server.pipeline.return_value = pipe
+        server.smembers.return_value = set()
+        pipe.execute.side_effect = [[set()], None]
+
+        with patch.object(redis_cache, "_get_redis_server", return_value=server):
+            redis_cache.flush("minions/foo")
+
+        srem_calls = _sremargs(pipe)
+        assert ("$BANKEYS_minions", "foo") in srem_calls
+
+    def test_flush_top_level_bank_no_parent_srems(self):
+        """A top-level bank has no parent; no SREM is issued for one."""
+        pipe = MagicMock()
+        server = MagicMock()
+        server.pipeline.return_value = pipe
+        server.smembers.return_value = set()
+        pipe.execute.side_effect = [[set()], None]
+
+        with patch.object(redis_cache, "_get_redis_server", return_value=server):
+            redis_cache.flush("minions")
+
+        srem_calls = _sremargs(pipe)
+        assert all(
+            not call_args[0].endswith("_") for call_args in srem_calls
+        ), f"unexpected parent-set SREM for a top-level bank: {srem_calls}"
+
+
+# ---------------------------------------------------------------------------
+# Integration: store -> list -> flush(child) -> list round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestStoreListFlushIntegration:
+    """
+    Drive ``store`` and ``list_`` against a small in-memory stub of
+    Redis SET semantics to prove the three fixes compose correctly:
+    after two stores ``list_`` returns both children; after flushing
+    one child it disappears from the parent listing.
+    """
+
+    @staticmethod
+    def _make_stub_redis():
+        """
+        Build a small stub of Redis SET semantics that distinguishes
+        between direct server operations (``server.smembers``) and
+        pipelined ones (``pipe.smembers`` + ``pipe.execute``). The
+        ``flush`` path in particular queues several ``smembers`` calls
+        on the pipeline and reads them back from ``execute()``; a
+        single shared mock would conflate the two.
+        """
+        sets = {}
+        pipe_smembers_queue = []
+
+        def fake_sadd(name, *values):
+            sets.setdefault(name, set()).update(values)
+
+        def fake_srem(name, *values):
+            if name in sets:
+                sets[name].difference_update(values)
+
+        def fake_smembers(name):
+            return {
+                v.encode() if isinstance(v, str) else v for v in sets.get(name, set())
+            }
+
+        def fake_pipe_smembers(name):
+            pipe_smembers_queue.append(fake_smembers(name))
+
+        def fake_pipe_delete(*names):
+            for n in names:
+                sets.pop(n, None)
+
+        def fake_pipe_execute():
+            result = list(pipe_smembers_queue)
+            pipe_smembers_queue.clear()
+            return result
+
+        server = MagicMock()
+        pipe = MagicMock()
+        server.pipeline.return_value = pipe
+
+        # Direct (non-pipelined) ops on the server itself.
+        server.sadd.side_effect = fake_sadd
+        server.srem.side_effect = fake_srem
+        server.smembers.side_effect = fake_smembers
+
+        # Pipelined ops: SET writes (sadd, srem, delete, set) take
+        # effect immediately on our in-memory dict; smembers is queued
+        # so that ``execute()`` can return the captured results.
+        pipe.sadd.side_effect = fake_sadd
+        pipe.srem.side_effect = fake_srem
+        pipe.smembers.side_effect = fake_pipe_smembers
+        pipe.delete.side_effect = fake_pipe_delete
+        pipe.set.side_effect = lambda *args, **kwargs: None
+        pipe.execute.side_effect = fake_pipe_execute
+
+        return server, pipe, sets
+
+    def test_store_two_then_list_returns_both(self):
+        server, _pipe, _sets = self._make_stub_redis()
+        with patch.object(redis_cache, "_get_redis_server", return_value=server):
+            redis_cache.store("minions/foo", "data", {"some": "grain"})
+            redis_cache.store("minions/bar", "data", {"some": "grain"})
+            result = sorted(redis_cache.list_("minions"))
+        assert result == ["bar", "foo"]
+
+    def test_store_then_flush_child_removes_from_list(self):
+        """
+        Headline of the parent-index orphan check: after flushing
+        ``minions/foo``, ``list_("minions")`` must return only
+        ``bar``, not both.
+        """
+        server, _pipe, _sets = self._make_stub_redis()
+        with patch.object(redis_cache, "_get_redis_server", return_value=server):
+            redis_cache.store("minions/foo", "data", {"some": "grain"})
+            redis_cache.store("minions/bar", "data", {"some": "grain"})
+            redis_cache.flush("minions/foo")
+            result = sorted(redis_cache.list_("minions"))
+        assert result == ["bar"], (
+            f"expected only ['bar'] after flushing minions/foo; "
+            f"got {result} -- parent-index orphan was not cleaned up"
+        )

--- a/tests/unit/engines/test_redis_sentinel.py
+++ b/tests/unit/engines/test_redis_sentinel.py
@@ -1,0 +1,147 @@
+"""
+Unit tests for the redis_sentinel engine.
+
+These regression tests cover two distinct bugs that together prevented
+the engine from being usable on any modern Salt installation:
+
+1. ``start()`` crashed on Python 3 with
+   ``AttributeError: 'dict_values' object has no attribute 'pop'``
+   because ``dict.values()`` no longer supports ``.pop()`` in Python 3.
+2. ``Listener`` built the redis client without ever passing a password,
+   so the engine could not authenticate to a Sentinel that required
+   AUTH.
+"""
+
+import pytest
+
+from saltext.redis.engines import redis_sentinel
+from unittest.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {redis_sentinel: {"__opts__": {"sock_dir": "/tmp/sock"}}}
+
+
+@pytest.fixture
+def patched_listener_deps():
+    """
+    Mock everything ``Listener.__init__`` reaches outside its own
+    module so that the constructor can be exercised in isolation.
+    """
+    fake_strict_redis = MagicMock(name="StrictRedis")
+    fake_redis_module = MagicMock(name="redis_module", StrictRedis=fake_strict_redis)
+    fake_event = MagicMock(name="get_master_event")
+
+    with patch.object(redis_sentinel, "redis", fake_redis_module), patch(
+        "salt.utils.event.get_master_event", fake_event
+    ):
+        yield fake_strict_redis
+
+
+@pytest.fixture
+def patched_localclient_and_listener():
+    """
+    Mock ``salt.client.LocalClient`` (returns a deterministic dict
+    mapping minion -> [ip]) and ``Listener`` (so we can inspect what
+    ``start()`` constructed without actually running the pubsub loop).
+    """
+    fake_local = MagicMock()
+    fake_local.cmd.return_value = {
+        "sentinel-1.example.com": ["10.0.0.5"],
+        "sentinel-2.example.com": ["10.0.0.6"],
+    }
+    fake_listener_class = MagicMock(name="Listener")
+    fake_listener_class.return_value = MagicMock(name="Listener instance")
+
+    with patch("salt.client.LocalClient") as lc_mock, patch.object(
+        redis_sentinel, "Listener", fake_listener_class
+    ):
+        lc_mock.return_value.__enter__.return_value = fake_local
+        yield fake_local, fake_listener_class
+
+
+# ---------------------------------------------------------------------------
+# Listener: password propagation
+# ---------------------------------------------------------------------------
+
+
+def test_listener_passes_password_to_redis_client(patched_listener_deps):
+    """
+    When a password is supplied to Listener, it must be forwarded to
+    redis.StrictRedis. Before the fix Listener had no ``password``
+    parameter at all -- this test would raise TypeError.
+    """
+    fake_strict_redis = patched_listener_deps
+    redis_sentinel.Listener(host="sentinel-1", port=26379, password="my-secret")
+    fake_strict_redis.assert_called_once_with(
+        host="sentinel-1", port=26379, password="my-secret", decode_responses=True
+    )
+
+
+def test_listener_default_password_is_none(patched_listener_deps):
+    """
+    With no password supplied, redis.StrictRedis must receive
+    ``password=None``. Pins the backwards-compatible default: omitting
+    the password keeps AUTH disabled, so the change is non-breaking
+    for existing operators who never set one.
+    """
+    fake_strict_redis = patched_listener_deps
+    redis_sentinel.Listener(host="sentinel-1", port=26379)
+    call = fake_strict_redis.call_args
+    assert call.kwargs.get("password") is None
+
+
+# ---------------------------------------------------------------------------
+# start(): dict_values.pop fix and password forwarding
+# ---------------------------------------------------------------------------
+
+
+def test_start_does_not_crash_on_dict_values_pop(patched_localclient_and_listener):
+    """
+    Headline regression: the original code called
+    ``local.cmd(...).values().pop()`` where ``.values()`` returns a
+    Python 3 ``dict_values`` view (no ``.pop`` method). The engine
+    therefore raised ``AttributeError`` on its very first call and
+    never actually ran. The fix wraps in ``list(...)``.
+    """
+    _fake_local, fake_listener_class = patched_localclient_and_listener
+    redis_sentinel.start(
+        hosts={"matching": "sentinel*", "port": 26379, "interface": "eth0"},
+        channels=["+switch-master"],
+    )
+    # Listener must have been constructed (which is what would not happen
+    # if .pop() raised) and its run loop must have been entered.
+    assert fake_listener_class.call_count == 1
+    fake_listener_class.return_value.run.assert_called_once()
+
+
+def test_start_forwards_password_to_listener(patched_localclient_and_listener):
+    """
+    When the engine YAML supplies ``password: '...'`` (which Salt's
+    engine loader hands to ``start()`` as a kwarg), the value must reach
+    the Listener constructor.
+    """
+    _fake_local, fake_listener_class = patched_localclient_and_listener
+    redis_sentinel.start(
+        hosts={"matching": "sentinel*", "port": 26379, "interface": "eth0"},
+        channels=["+switch-master"],
+        password="my-secret",
+    )
+    call = fake_listener_class.call_args
+    assert call.kwargs["password"] == "my-secret"
+
+
+def test_start_default_password_is_none(patched_localclient_and_listener):
+    """
+    When the YAML does not specify a password, Listener must be
+    constructed with ``password=None``. Pins backwards compatibility
+    for existing engine configs that never set one.
+    """
+    _fake_local, fake_listener_class = patched_localclient_and_listener
+    redis_sentinel.start(
+        hosts={"matching": "sentinel*", "port": 26379, "interface": "eth0"},
+        channels=["+switch-master"],
+    )
+    call = fake_listener_class.call_args
+    assert call.kwargs.get("password") is None

--- a/tests/unit/engines/test_redis_sentinel.py
+++ b/tests/unit/engines/test_redis_sentinel.py
@@ -145,3 +145,39 @@ def test_start_default_password_is_none(patched_localclient_and_listener):
     )
     call = fake_listener_class.call_args
     assert call.kwargs.get("password") is None
+
+
+def test_start_logs_and_returns_when_no_minions_match(caplog):
+    """
+    When the ``matching`` target hits zero minions, ``local.cmd`` returns
+    an empty dict. The engine must log a clear error and return rather
+    than dereferencing the empty result -- the previous code crashed with
+    ``IndexError`` from ``.pop()``, which gave operators no hint that the
+    real problem was a misconfigured target pattern.
+    """
+    fake_local = MagicMock()
+    fake_local.cmd.return_value = {}
+    fake_listener_class = MagicMock(name="Listener")
+
+    with patch("salt.client.LocalClient") as lc_mock, patch.object(
+        redis_sentinel, "Listener", fake_listener_class
+    ):
+        lc_mock.return_value.__enter__.return_value = fake_local
+        with caplog.at_level("ERROR", logger="saltext.redis.engines.redis_sentinel"):
+            redis_sentinel.start(
+                hosts={
+                    "matching": "no-such-minion-*",
+                    "port": 26379,
+                    "interface": "eth0",
+                },
+                channels=["+switch-master"],
+            )
+
+    fake_listener_class.assert_not_called()
+    assert any(
+        "no minions matched" in rec.message
+        and "no-such-minion-*" in rec.message
+        for rec in caplog.records
+    ), "expected an ERROR log explaining the empty match; got: {}".format(
+        [rec.message for rec in caplog.records]
+    )

--- a/tests/unit/modules/test_redismod.py
+++ b/tests/unit/modules/test_redismod.py
@@ -5,7 +5,7 @@ Test cases for salt.modules.redismod
 """
 
 from datetime import datetime
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -481,3 +481,123 @@ def test_zrange():
     Test to get a range of values from a sorted set in Redis by index
     """
     assert redismod.zrange("key", "start", "stop") == "A"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the get_master_ip positional-args bug.
+#
+# get_master_ip used to forward its arguments to _connect positionally:
+#
+#     server = _connect(host, port, password)
+#
+# but _connect's positional signature is (host, port, db, password). The
+# password value therefore landed in the db slot, while the actual password
+# parameter of _connect fell through to config.option("redis.password").
+# The fix passes arguments by keyword.
+# ---------------------------------------------------------------------------
+
+
+def _fake_redis_server(master_host="10.0.0.5", master_port="6379"):
+    """Build a MagicMock that quacks like the redis client _connect returns."""
+    server = MagicMock()
+    server.info.return_value = {
+        "master_host": master_host,
+        "master_port": master_port,
+    }
+    return server
+
+
+def test_get_master_ip_passes_password_as_keyword():
+    """
+    get_master_ip must forward the password to _connect as a keyword
+    argument, not as a positional argument that would land in _connect's
+    `db` slot.
+    """
+    server = _fake_redis_server()
+    with patch.object(redismod, "_connect", return_value=server) as mock_connect:
+        result = redismod.get_master_ip(host="redis-1", port=6379, password="my-secret")
+
+    mock_connect.assert_called_once_with(
+        host="redis-1", port=6379, password="my-secret"
+    )
+    assert result == {"master_host": "10.0.0.5", "master_port": "6379"}
+
+
+def test_get_master_ip_does_not_send_password_as_db():
+    """
+    Tight regression check: the password value must never appear in
+    _connect's positional args nor in its `db` keyword slot.
+    """
+    server = _fake_redis_server(master_host="x", master_port="y")
+    with patch.object(redismod, "_connect", return_value=server) as mock_connect:
+        redismod.get_master_ip(host="h", port=1234, password="MY_SECRET")
+
+    call = mock_connect.call_args
+    assert "MY_SECRET" not in call.args, (
+        "password leaked into _connect positional args; this is the original bug."
+    )
+    assert call.kwargs.get("db") != "MY_SECRET", (
+        "password leaked into _connect's db keyword; this is the original bug."
+    )
+    assert call.kwargs.get("password") == "MY_SECRET"
+
+
+def test_get_master_ip_no_args_passes_none_to_connect():
+    """
+    With no explicit arguments, _connect must receive None for each
+    parameter so that _connect itself can resolve the values from
+    config.option(...). The fix must not change this behaviour.
+    """
+    server = _fake_redis_server(master_host="", master_port="")
+    with patch.object(redismod, "_connect", return_value=server) as mock_connect:
+        result = redismod.get_master_ip()
+
+    mock_connect.assert_called_once_with(host=None, port=None, password=None)
+    assert result == {"master_host": "", "master_port": ""}
+
+
+def test_get_master_ip_returns_dict_with_info_fields_missing():
+    """
+    If the Redis INFO response does not include master_host/master_port
+    (e.g. when querying a master that has no master), the function still
+    returns a dict with both keys present, defaulted to "". The fix to
+    the positional-args bug must not regress this.
+    """
+    server = MagicMock()
+    server.info.return_value = {}  # no master_host, no master_port
+    with patch.object(redismod, "_connect", return_value=server):
+        result = redismod.get_master_ip(host="h", port=1, password="p")
+
+    assert result == {"master_host": "", "master_port": ""}
+
+
+def test_get_master_ip_with_only_password_kwarg_routes_password_correctly():
+    """
+    The most common real-world failure pattern of the original bug:
+    operator passes ``password=...`` and relies on host/port defaults
+    coming from config. The password must still arrive at _connect via
+    the password keyword, not via the db slot.
+    """
+    server = _fake_redis_server()
+    with patch.object(redismod, "_connect", return_value=server) as mock_connect:
+        redismod.get_master_ip(password="only-password")
+
+    mock_connect.assert_called_once_with(host=None, port=None, password="only-password")
+
+
+def test_get_master_ip_called_positionally_routes_password_correctly():
+    """
+    The public function signature accepts positional arguments. Even
+    when callers use the positional style, password must end up in
+    _connect's password keyword, not its db slot. This guards against
+    a regression where someone might re-introduce positional forwarding
+    to _connect ('it worked when called positionally so it must be
+    fine').
+    """
+    server = _fake_redis_server()
+    with patch.object(redismod, "_connect", return_value=server) as mock_connect:
+        redismod.get_master_ip("redis-1", 6379, "my-secret")
+
+    mock_connect.assert_called_once_with(
+        host="redis-1", port=6379, password="my-secret"
+    )

--- a/tests/unit/modules/test_redismod.py
+++ b/tests/unit/modules/test_redismod.py
@@ -11,6 +11,11 @@ import pytest
 
 from saltext.redis.modules import redismod
 
+# Capture the real ``_connect`` reference before the loader fixture replaces
+# it with a MagicMock. The tests for ``_connect`` itself need the real
+# implementation; everything else uses the mocked one.
+_REAL_CONNECT = redismod._connect
+
 
 class Mockredis:
     """
@@ -601,3 +606,144 @@ def test_get_master_ip_called_positionally_routes_password_correctly():
     mock_connect.assert_called_once_with(
         host="redis-1", port=6379, password="my-secret"
     )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the _connect "if not db" bug.
+#
+# _connect used the truthy check ``if not db`` to decide whether to fall
+# back to ``config.option("redis.db")``. That predicate is also true for
+# ``db=0`` -- the default Redis database index, and a perfectly valid
+# explicit value. As a result, callers who explicitly targeted db 0 had
+# their argument silently replaced by the configured value.
+#
+# The fix uses ``if db is None`` so that only the absent-argument case
+# triggers the fall-back. The other arguments (host/port/password) keep
+# their truthy-check semantics on purpose: empty string and 0 are not
+# legitimate values for a hostname or port, and "" is not a meaningful
+# password override.
+# ---------------------------------------------------------------------------
+
+
+def _connect_test_env(config_options):
+    """
+    Build the (config_option_mock, fake_strict_redis, fake_redis_module)
+    triple used by every _connect test. Mocking redis.StrictRedis lets us
+    assert exactly which (host, port, db, password) tuple _connect built;
+    wrapping config.option in a MagicMock lets us assert which keys it
+    queried (and which it skipped).
+    """
+    config_option_mock = MagicMock(
+        side_effect=lambda key, *args, **kwargs: config_options.get(key)
+    )
+    fake_strict_redis = MagicMock(name="StrictRedis")
+    fake_redis_module = MagicMock(name="redis_module", StrictRedis=fake_strict_redis)
+    return config_option_mock, fake_strict_redis, fake_redis_module
+
+
+def test_connect_passes_db_zero_through():
+    """
+    The headline regression test: when the caller explicitly passes
+    ``db=0``, _connect must hand 0 to StrictRedis verbatim and must NOT
+    consult ``config.option("redis.db")``.
+    """
+    config_option_mock, fake_strict_redis, fake_redis_module = _connect_test_env(
+        {
+            "redis.host": "config-host",
+            "redis.port": 6380,
+            "redis.db": "5",
+            "redis.password": "config-pass",
+        }
+    )
+
+    with patch.object(
+        redismod, "__salt__", {"config.option": config_option_mock}, create=True
+    ), patch.object(redismod, "redis", fake_redis_module):
+        _REAL_CONNECT(host="h", port=6379, db=0, password="p")
+
+    call = fake_strict_redis.call_args
+    assert (
+        call.args[2] == 0
+    ), f"db=0 was replaced (got {call.args[2]!r}); this is the bug"
+
+    queried_keys = [c.args[0] for c in config_option_mock.call_args_list]
+    assert "redis.db" not in queried_keys, (
+        "_connect queried config.option('redis.db') even though the caller "
+        "supplied db=0; this is the bug"
+    )
+
+
+def test_connect_falls_back_to_config_when_db_is_none():
+    """
+    With db=None (the default), _connect must read redis.db from config
+    and pass the resulting value to StrictRedis.
+    """
+    config_option_mock, fake_strict_redis, fake_redis_module = _connect_test_env(
+        {
+            "redis.host": "config-host",
+            "redis.port": 6380,
+            "redis.db": "7",
+            "redis.password": "config-pass",
+        }
+    )
+
+    with patch.object(
+        redismod, "__salt__", {"config.option": config_option_mock}, create=True
+    ), patch.object(redismod, "redis", fake_redis_module):
+        _REAL_CONNECT()
+
+    call = fake_strict_redis.call_args
+    assert call.args == ("config-host", 6380, "7", "config-pass")
+
+    queried_keys = [c.args[0] for c in config_option_mock.call_args_list]
+    assert "redis.db" in queried_keys
+
+
+def test_connect_passes_explicit_nonzero_db_through():
+    """
+    Sanity check: an explicit non-zero db value is honoured. This already
+    worked before the fix (because the truthy check passed for non-zero),
+    but the test pins the behaviour so future refactors do not regress it.
+    """
+    config_option_mock, fake_strict_redis, fake_redis_module = _connect_test_env(
+        {"redis.db": "should-not-be-used"}
+    )
+
+    with patch.object(
+        redismod, "__salt__", {"config.option": config_option_mock}, create=True
+    ), patch.object(redismod, "redis", fake_redis_module):
+        _REAL_CONNECT(host="h", port=6379, db=5, password="p")
+
+    call = fake_strict_redis.call_args
+    assert call.args[2] == 5
+
+    queried_keys = [c.args[0] for c in config_option_mock.call_args_list]
+    assert "redis.db" not in queried_keys
+
+
+def test_connect_other_args_keep_truthy_fallback_semantics():
+    """
+    The fix narrows the fall-back predicate only for ``db``. The host,
+    port and password arguments keep their existing truthy-check
+    semantics on purpose -- empty string is not a legitimate hostname,
+    0 is not a legitimate port, and "" is not a meaningful password
+    override. This test pins that scope so the fix does not silently
+    widen.
+    """
+    config_option_mock, fake_strict_redis, fake_redis_module = _connect_test_env(
+        {
+            "redis.host": "config-host",
+            "redis.port": 6380,
+            "redis.password": "config-pass",
+        }
+    )
+
+    with patch.object(
+        redismod, "__salt__", {"config.option": config_option_mock}, create=True
+    ), patch.object(redismod, "redis", fake_redis_module):
+        _REAL_CONNECT(host="", port=None, db=2, password=None)
+
+    call = fake_strict_redis.call_args
+    # host="" -> falls back; port=None -> falls back; db=2 -> kept;
+    # password=None -> falls back.
+    assert call.args == ("config-host", 6380, 2, "config-pass")

--- a/tests/unit/returners/test_redis_return.py
+++ b/tests/unit/returners/test_redis_return.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -103,3 +103,116 @@ def test_when_platform_is_not_proxy_it_should_use_returner_opts(
         password="super secret!",
         decode_responses=True,
     )
+
+
+# ---------------------------------------------------------------------------
+# get_jids / clean_old_jobs: SCAN replaces blocking KEYS
+# ---------------------------------------------------------------------------
+
+
+def _serv_with_scan(scan_data, mget_data=None):
+    """
+    Build a ``serv`` mock whose ``scan_iter(match=...)`` returns the
+    keys for a given pattern, plus a ``keys(...)`` that raises -- so
+    the test fails loudly if the production code falls back to ``KEYS``.
+    """
+    serv = MagicMock(name="redis_serv")
+
+    def fake_scan_iter(match=None, **kwargs):
+        return iter(scan_data.get(match, []))
+
+    def fake_keys(*args, **kwargs):
+        raise AssertionError(
+            "production code called serv.keys(...); it must use "
+            "scan_iter() instead to avoid blocking the Redis server"
+        )
+
+    serv.scan_iter.side_effect = fake_scan_iter
+    serv.keys.side_effect = fake_keys
+    if mget_data is not None:
+        serv.mget.return_value = mget_data
+    return serv
+
+
+def test_get_jids_uses_scan_iter_not_keys():
+    """
+    Headline regression: ``get_jids`` must walk the keyspace with
+    ``SCAN``, not the blocking ``KEYS load:*``.
+    """
+    serv = _serv_with_scan(
+        scan_data={"load:*": ["load:20240101", "load:20240102"]},
+        mget_data=[None, None],  # contents don't matter for this test
+    )
+    with patch.object(redis_return, "_get_serv", return_value=serv):
+        redis_return.get_jids()
+
+    matches = [call.kwargs.get("match") for call in serv.scan_iter.call_args_list]
+    assert "load:*" in matches
+
+
+def test_get_jids_handles_no_jobs():
+    """
+    With no ``load:*`` keys in Redis, ``get_jids`` must return an empty
+    dict (and must not call ``mget`` with an empty list, which some
+    Redis clients reject). Pins the behaviour after the SCAN switch.
+    """
+    serv = _serv_with_scan(scan_data={"load:*": []})
+    with patch.object(redis_return, "_get_serv", return_value=serv):
+        result = redis_return.get_jids()
+
+    assert result == {}
+    serv.mget.assert_not_called()
+
+
+def test_clean_old_jobs_uses_scan_iter_not_keys():
+    """
+    Headline regression: ``clean_old_jobs`` must enumerate both
+    ``ret:*`` and ``load:*`` via ``SCAN``. Both calls were blocking
+    ``KEYS`` before the fix.
+    """
+    serv = _serv_with_scan(
+        scan_data={
+            "ret:*": ["ret:20240101", "ret:20240102"],
+            "load:*": ["load:20240102"],
+        }
+    )
+    with patch.object(redis_return, "_get_serv", return_value=serv):
+        redis_return.clean_old_jobs()
+
+    matches = [call.kwargs.get("match") for call in serv.scan_iter.call_args_list]
+    assert "ret:*" in matches
+    assert "load:*" in matches
+
+
+def test_clean_old_jobs_removes_only_orphan_ret_keys():
+    """
+    End-to-end behaviour after the SCAN switch: ``ret:<jid>`` keys
+    whose ``load:<jid>`` counterpart no longer exists must be deleted.
+    Active jobs (``ret`` with a matching ``load``) must be left alone.
+    """
+    serv = _serv_with_scan(
+        scan_data={
+            "ret:*": ["ret:dead-jid", "ret:alive-jid"],
+            "load:*": ["load:alive-jid"],
+        }
+    )
+    with patch.object(redis_return, "_get_serv", return_value=serv):
+        redis_return.clean_old_jobs()
+
+    serv.delete.assert_called_once()
+    deleted = set(serv.delete.call_args.args)
+    assert deleted == {"ret:dead-jid"}
+
+
+def test_clean_old_jobs_no_orphans_no_delete():
+    """No orphan keys -> no delete call. Pins backward compatibility."""
+    serv = _serv_with_scan(
+        scan_data={
+            "ret:*": ["ret:alive"],
+            "load:*": ["load:alive"],
+        }
+    )
+    with patch.object(redis_return, "_get_serv", return_value=serv):
+        redis_return.clean_old_jobs()
+
+    serv.delete.assert_not_called()

--- a/tests/unit/returners/test_redis_return.py
+++ b/tests/unit/returners/test_redis_return.py
@@ -216,3 +216,73 @@ def test_clean_old_jobs_no_orphans_no_delete():
         redis_return.clean_old_jobs()
 
     serv.delete.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# returner(): TTL on the {minion}:{fun} last-jid pointer
+# ---------------------------------------------------------------------------
+
+
+def _returner_pipeline_mock(ttl=3600):
+    """
+    Mock the ``serv.pipeline()`` returned by the returner so each
+    call recorded on the pipeline is observable. ``_get_ttl()`` is
+    patched to return a deterministic value so the test can match it
+    exactly.
+    """
+    pipeline = MagicMock(name="pipeline")
+    serv = MagicMock(name="redis_serv")
+    serv.pipeline.return_value = pipeline
+    return serv, pipeline
+
+
+def test_returner_sets_ttl_on_minion_fun_pointer():
+    """
+    Headline regression: ``<minion>:<fun>`` key must be written with
+    ``ex=_get_ttl()`` so it expires on the same schedule as the rest
+    of the returner data. Before the fix it was written with no TTL
+    and accumulated forever.
+    """
+    serv, pipeline = _returner_pipeline_mock()
+    ret = {"id": "minion-1", "jid": "20240101", "fun": "test.ping"}
+
+    with patch.object(redis_return, "_get_serv", return_value=serv), patch.object(
+        redis_return, "_get_ttl", return_value=3600
+    ):
+        redis_return.returner(ret)
+
+    set_calls = [
+        call
+        for call in pipeline.set.call_args_list
+        if call.args and call.args[0] == "minion-1:test.ping"
+    ]
+    assert len(set_calls) == 1, (
+        f"expected exactly one set('minion-1:test.ping', ...); "
+        f"got {pipeline.set.call_args_list}"
+    )
+    set_call = set_calls[0]
+    assert set_call.kwargs.get("ex") == 3600, (
+        f"<minion>:<fun> pointer must be set with ex=_get_ttl(); "
+        f"got kwargs={set_call.kwargs!r}"
+    )
+
+
+def test_returner_still_writes_all_four_keys():
+    """
+    Sanity: the TTL fix must not change which keys the returner
+    writes. The four canonical operations (hset, expire, set, sadd)
+    must all still appear on the pipeline.
+    """
+    serv, pipeline = _returner_pipeline_mock()
+    ret = {"id": "minion-1", "jid": "20240101", "fun": "test.ping"}
+
+    with patch.object(redis_return, "_get_serv", return_value=serv), patch.object(
+        redis_return, "_get_ttl", return_value=3600
+    ):
+        redis_return.returner(ret)
+
+    pipeline.hset.assert_called_once()
+    pipeline.expire.assert_called_once()
+    pipeline.set.assert_called_once()
+    pipeline.sadd.assert_called_once_with("minions", "minion-1")
+    pipeline.execute.assert_called_once()

--- a/tests/unit/returners/test_redis_return.py
+++ b/tests/unit/returners/test_redis_return.py
@@ -286,3 +286,91 @@ def test_returner_still_writes_all_four_keys():
     pipeline.set.assert_called_once()
     pipeline.sadd.assert_called_once_with("minions", "minion-1")
     pipeline.execute.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# get_fun: reads from ret:<jid> hash, not from non-existent <minion>:<jid>
+# ---------------------------------------------------------------------------
+
+
+def test_get_fun_reads_data_from_ret_hash():
+    """
+    Headline regression: ``get_fun`` must read the per-minion return
+    payload from ``HGET ret:<jid> <minion>``. Before the fix it did
+    ``GET <minion>:<jid>`` -- a key the module never writes -- and
+    therefore always returned ``{}``.
+    """
+    serv = MagicMock(name="redis_serv")
+    serv.smembers.return_value = ["minion-1", "minion-2"]
+    pointer_table = {
+        "minion-1:test.ping": "20240101",
+        "minion-2:test.ping": "20240102",
+    }
+    serv.get.side_effect = pointer_table.get
+    return_table = {
+        ("ret:20240101", "minion-1"): '{"jid": "20240101", "return": "ok-1"}',
+        ("ret:20240102", "minion-2"): '{"jid": "20240102", "return": "ok-2"}',
+    }
+    serv.hget.side_effect = lambda hashkey, field: return_table.get((hashkey, field))
+
+    with patch.object(redis_return, "_get_serv", return_value=serv):
+        result = redis_return.get_fun("test.ping")
+
+    assert result == {
+        "minion-1": {"jid": "20240101", "return": "ok-1"},
+        "minion-2": {"jid": "20240102", "return": "ok-2"},
+    }
+    assert all(
+        call.args[0] not in {"minion-1:20240101", "minion-2:20240102"}
+        for call in serv.get.call_args_list
+    ), "get_fun queried the non-existent <minion>:<jid> key; this is the bug"
+
+
+def test_get_fun_skips_minions_with_no_recent_jid():
+    """
+    Minion is in the ``minions`` set but has never run the requested
+    fun -> ``<minion>:<fun>`` returns None. Skip without consulting
+    ``ret:<jid>`` and without raising.
+    """
+    serv = MagicMock(name="redis_serv")
+    serv.smembers.return_value = ["minion-1"]
+    serv.get.return_value = None
+
+    with patch.object(redis_return, "_get_serv", return_value=serv):
+        result = redis_return.get_fun("test.ping")
+
+    assert result == {}
+    serv.hget.assert_not_called()
+
+
+def test_get_fun_handles_missing_hash_field():
+    """
+    The pointer says the latest jid is X, but the ``ret:X`` hash no
+    longer holds a field for this minion (e.g. it expired). Skip
+    cleanly.
+    """
+    serv = MagicMock(name="redis_serv")
+    serv.smembers.return_value = ["minion-1"]
+    serv.get.return_value = "20240101"
+    serv.hget.return_value = None
+
+    with patch.object(redis_return, "_get_serv", return_value=serv):
+        result = redis_return.get_fun("test.ping")
+
+    assert result == {}
+
+
+def test_get_fun_no_minions_returns_empty():
+    """
+    No minions in the ``minions`` set -> empty dict. Pins backwards
+    compatibility for fresh installs.
+    """
+    serv = MagicMock(name="redis_serv")
+    serv.smembers.return_value = []
+
+    with patch.object(redis_return, "_get_serv", return_value=serv):
+        result = redis_return.get_fun("test.ping")
+
+    assert result == {}
+    serv.get.assert_not_called()
+    serv.hget.assert_not_called()

--- a/tests/unit/tokens/test_rediscluster.py
+++ b/tests/unit/tokens/test_rediscluster.py
@@ -1,0 +1,188 @@
+"""
+Unit tests for the rediscluster eauth token storage.
+
+These regression tests cover the bug where ``_redis_client`` used
+``decode_responses=True``, which caused ``redis_client.get()`` and
+``redis_client.keys()`` to return ``str``. Two callers in the same
+module were then broken:
+
+- ``get_token`` deserialises with ``salt.payload.loads``, which calls
+  ``msgpack.unpackb`` under the hood; ``msgpack`` requires ``bytes``
+  and raises ``TypeError`` for ``str``.
+- ``list_tokens`` calls ``.decode("utf8")`` on each key, which
+  ``str`` does not support.
+
+Both errors were swallowed by a broad ``except Exception`` that
+returned ``{}`` / ``[]``, so the bug was invisible to operators --
+eauth tokens were never readable, but Salt logged a warning and
+behaved as though the token simply did not exist.
+"""
+
+import pytest
+
+import salt.payload
+from saltext.redis.tokens import rediscluster as rediscluster_tokens
+from unittest.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {rediscluster_tokens: {}}
+
+
+@pytest.fixture
+def patched_rediscluster():
+    """
+    Replace ``rediscluster.RedisCluster`` with a factory that
+    returns a controllable mock client. ``create=True`` covers
+    environments where the optional ``rediscluster`` package is not
+    installed (the symbol is then absent from the module under test).
+    """
+    fake_client = MagicMock(name="RedisCluster_instance")
+    fake_strict_cluster = MagicMock(
+        name="RedisCluster_class", return_value=fake_client
+    )
+    fake_rediscluster = MagicMock(
+        name="rediscluster_module", RedisCluster=fake_strict_cluster
+    )
+
+    with patch.object(
+        rediscluster_tokens, "rediscluster", fake_rediscluster, create=True
+    ):
+        yield fake_strict_cluster, fake_client
+
+
+@pytest.fixture
+def fake_opts():
+    return {"eauth_redis_host": "redis-cluster-1", "eauth_redis_port": 6379}
+
+
+# ---------------------------------------------------------------------------
+# _redis_client: decode_responses must NOT be enabled
+# ---------------------------------------------------------------------------
+
+
+def test_redis_client_does_not_enable_decode_responses(patched_rediscluster, fake_opts):
+    """
+    Headline regression: enabling ``decode_responses=True`` is what
+    caused both ``get_token`` and ``list_tokens`` to fail. The fix
+    removes that argument so the cluster client returns bytes for the
+    msgpack-serialised values.
+    """
+    fake_strict_cluster, _ = patched_rediscluster
+    rediscluster_tokens._redis_client(fake_opts)
+
+    fake_strict_cluster.assert_called_once()
+    kwargs = fake_strict_cluster.call_args.kwargs
+    assert kwargs.get("decode_responses") is not True, (
+        "decode_responses=True breaks salt.payload.loads (msgpack rejects "
+        "str) and list_tokens (str has no .decode); this is the bug"
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_token: round-trip with msgpack bytes
+# ---------------------------------------------------------------------------
+
+
+def test_get_token_returns_full_data_for_existing_token(
+    patched_rediscluster, fake_opts
+):
+    """
+    The end-to-end check: with the fix, ``get_token`` reads the
+    msgpack-serialised bytes from the cluster and returns the
+    deserialised token data. Before the fix, ``redis_client.get``
+    returned a ``str`` and ``msgpack.unpackb`` raised TypeError, which
+    the broad ``except`` caught and turned into ``{}``.
+    """
+    _, fake_client = patched_rediscluster
+    tdata = {"token": "abcd1234", "name": "alice", "eauth": "pam"}
+    serialised = salt.payload.dumps(tdata)
+    fake_client.get.return_value = serialised
+
+    result = rediscluster_tokens.get_token(fake_opts, "abcd1234")
+    assert result == tdata
+
+
+def test_get_token_returns_empty_dict_for_missing_token(
+    patched_rediscluster, fake_opts
+):
+    """
+    When the cluster has no entry for the requested token, ``get``
+    returns ``None`` and ``salt.payload.loads(None)`` raises; the
+    function must keep its existing contract of returning ``{}`` in
+    that case (used by callers as "no such token").
+    """
+    _, fake_client = patched_rediscluster
+    fake_client.get.return_value = None
+
+    result = rediscluster_tokens.get_token(fake_opts, "nonexistent")
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# list_tokens: bytes keys decoded back to str
+# ---------------------------------------------------------------------------
+
+
+def test_list_tokens_returns_decoded_str_keys(patched_rediscluster, fake_opts):
+    """
+    With the fix, ``redis_client.keys()`` returns ``list[bytes]`` and
+    the comprehension ``[k.decode("utf8") for k in ...]`` produces
+    ``list[str]``. Before the fix, decode_responses=True made keys
+    arrive as ``str`` already and ``str.decode("utf8")`` raised
+    AttributeError, swallowed into ``[]``.
+    """
+    _, fake_client = patched_rediscluster
+    fake_client.keys.return_value = [b"token-1", b"token-2", b"token-3"]
+
+    result = rediscluster_tokens.list_tokens(fake_opts)
+    assert result == ["token-1", "token-2", "token-3"]
+    # And every element is genuinely a Python str, not bytes.
+    assert all(isinstance(t, str) for t in result)
+
+
+def test_list_tokens_returns_empty_when_no_tokens(patched_rediscluster, fake_opts):
+    """No tokens in the cluster -> empty list. Pins backward compat."""
+    _, fake_client = patched_rediscluster
+    fake_client.keys.return_value = []
+
+    result = rediscluster_tokens.list_tokens(fake_opts)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# mk_token + get_token: round-trip with the same client
+# ---------------------------------------------------------------------------
+
+
+def test_mk_token_then_get_token_round_trip(patched_rediscluster, fake_opts):
+    """
+    End-to-end: ``mk_token`` writes msgpack bytes via ``set``;
+    ``get_token`` reads them back via ``get`` and deserialises. With
+    the fix, both ends agree on bytes; before the fix, ``get_token``
+    received str and silently failed.
+    """
+    _, fake_client = patched_rediscluster
+
+    # mk_token loops on .get to ensure the token does not already exist;
+    # return None so the loop terminates immediately.
+    fake_client.get.return_value = None
+
+    tdata = {"name": "alice", "eauth": "pam"}
+    minted = rediscluster_tokens.mk_token(fake_opts, tdata)
+    assert "token" in minted
+    assert minted["name"] == "alice"
+
+    # mk_token must have called set() once with the msgpack-serialised
+    # tdata as its second positional arg.
+    fake_client.set.assert_called_once()
+    set_args = fake_client.set.call_args.args
+    stored_token, stored_payload = set_args
+    assert stored_token == minted["token"]
+    assert salt.payload.loads(stored_payload) == minted
+
+    # Now simulate the read path: get returns the same payload bytes.
+    fake_client.get.return_value = stored_payload
+    fetched = rediscluster_tokens.get_token(fake_opts, stored_token)
+    assert fetched == minted


### PR DESCRIPTION
### What does this PR do?

Mirrors **eight** of the nine Redis fixes landing in [saltstack/salt#69040](https://github.com/saltstack/salt/pull/69040) into this extension, per [@dwoz's request](https://github.com/saltstack/salt/pull/69040#issuecomment) on that PR. The ninth fix (redis_return reading `redis.password`) was already applied here in commit `3417691` ("Add password support to Redis returner") and is therefore skipped.

Each commit corresponds 1:1 to one upstream Salt issue and is reviewable in isolation. Every commit ships its own tests; running `pytest tests/unit/` produces 79 passing tests total.

### What issues does this PR fix or reference?

Mirrors the following upstream Salt issues:

| Commit | Upstream issue |
|---|---|
| `Fix redis.get_master_ip silently dropping the password argument` | saltstack/salt#69029 |
| `Fix _connect rejecting valid db=0 due to truthy fallback check` | saltstack/salt#69030 |
| `Fix redis_sentinel engine: dict_values.pop AttributeError and missing AUTH` | saltstack/salt#69031 |
| `Fix redis_cache hierarchical-bank semantics: list, flush, decode` | saltstack/salt#69033 |
| `Fix tokens/rediscluster: decode_responses+msgpack mismatch breaks token reads` | saltstack/salt#69035 |
| `Replace blocking KEYS with SCAN in redis_return get_jids and clean_old_jobs` | saltstack/salt#69037 |
| `Fix redis_return leaking <minion>:<fun> last-jid pointer keys without TTL` | saltstack/salt#69038 |
| `Fix redis_return.get_fun reading a key the module never writes` | saltstack/salt#69039 |

### Notes

- Each upstream Salt issue contains the full diagnosis (steps to reproduce, root cause, before/after behaviour). Commit bodies summarise the same information for reviewers staying inside this repo.
- `redis_cache` had ~100 lines of formatting / comment divergence vs upstream Salt; the actual hierarchical-bank bug was identical and the fix applied with a small adaptation.
- `tokens/rediscluster` uses `RedisCluster` here (the module-level name shipped by `redis-py-cluster`), not `StrictRedisCluster` as in upstream Salt; the fix and tests are adapted for that.
- `redis_sentinel` and `tokens/rediscluster` did not previously have unit tests in this extension; this PR adds `tests/unit/engines/test_redis_sentinel.py` and `tests/unit/tokens/test_rediscluster.py` (with `__init__.py`).

Changelog filenames currently use placeholder five-digit IDs (`9900N.<type>.md`) — happy to rename to this PR's number once you assign one.

### Local verification

```
$ pip install -e .
$ pytest tests/unit/ -q
79 passed, 1 warning
```

### Commits signed with GPG?

No.